### PR TITLE
Allow for subscriptions which contain oldValue from didSet

### DIFF
--- a/Notice.xcodeproj/project.pbxproj
+++ b/Notice.xcodeproj/project.pbxproj
@@ -8,9 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		396F33661BB3461F00792AB5 /* Notice.h in Headers */ = {isa = PBXBuildFile; fileRef = 396F33651BB3461F00792AB5 /* Notice.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		396F336E1BB3464300792AB5 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396F336D1BB3464300792AB5 /* Observable.swift */; settings = {ASSET_TAGS = (); }; };
-		396F33701BB3468300792AB5 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396F336F1BB3468300792AB5 /* Subscription.swift */; settings = {ASSET_TAGS = (); }; };
-		396F33721BB346C800792AB5 /* Subscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396F33711BB346C800792AB5 /* Subscriptions.swift */; settings = {ASSET_TAGS = (); }; };
+		396F336E1BB3464300792AB5 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396F336D1BB3464300792AB5 /* Observable.swift */; };
+		396F33701BB3468300792AB5 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396F336F1BB3468300792AB5 /* Subscription.swift */; };
+		396F33721BB346C800792AB5 /* Subscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396F33711BB346C800792AB5 /* Subscriptions.swift */; };
+		62839F6B1C80BD3E0076F99F /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62839F6A1C80BD3E0076F99F /* Event.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +21,7 @@
 		396F336D1BB3464300792AB5 /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		396F336F1BB3468300792AB5 /* Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 		396F33711BB346C800792AB5 /* Subscriptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscriptions.swift; sourceTree = "<group>"; };
+		62839F6A1C80BD3E0076F99F /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +59,7 @@
 				396F336D1BB3464300792AB5 /* Observable.swift */,
 				396F336F1BB3468300792AB5 /* Subscription.swift */,
 				396F33711BB346C800792AB5 /* Subscriptions.swift */,
+				62839F6A1C80BD3E0076F99F /* Event.swift */,
 			);
 			path = Notice;
 			sourceTree = "<group>";
@@ -140,6 +143,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62839F6B1C80BD3E0076F99F /* Event.swift in Sources */,
 				396F33721BB346C800792AB5 /* Subscriptions.swift in Sources */,
 				396F33701BB3468300792AB5 /* Subscription.swift in Sources */,
 				396F336E1BB3464300792AB5 /* Observable.swift in Sources */,

--- a/Notice/Event.swift
+++ b/Notice/Event.swift
@@ -1,0 +1,29 @@
+public protocol Event {
+    typealias ValueType
+    typealias HandlerType
+
+    var value: ValueType { get }
+    func handle(handler: HandlerType)
+}
+
+public struct NewEvent<T>: Event {
+    public let value: T
+
+    public func handle(handler: T -> Void) {
+        handler(value)
+    }
+}
+
+public struct NewOldEvent<T>: Event {
+    public let value: T
+    public let oldValue: T?
+
+    init(value: T, oldValue: T? = nil) {
+        self.value = value
+        self.oldValue = oldValue
+    }
+
+    public func handle(handler: (old: T?, new: T) -> Void) {
+        handler(old: oldValue, new: value)
+    }
+}

--- a/Notice/Subscription.swift
+++ b/Notice/Subscription.swift
@@ -1,5 +1,5 @@
-public class Subscription<T>: Hashable {
-    public typealias EventHandler = T -> Void
+public class Subscription<EventType: Event>: Hashable {
+    public typealias EventHandler = EventType.HandlerType
 
     let handler: EventHandler
     private let UUID = NSUUID().UUIDString
@@ -11,8 +11,12 @@ public class Subscription<T>: Hashable {
     public var hashValue: Int {
         return UUID.hashValue
     }
+
+    func handle(event: EventType) {
+        event.handle(handler)
+    }
 }
 
-public func ==<T>(lhs: Subscription<T>, rhs: Subscription<T>) -> Bool {
+public func ==<EventType: Event>(lhs: Subscription<EventType>, rhs: Subscription<EventType>) -> Bool {
     return lhs.UUID == rhs.UUID
 }

--- a/Notice/Subscriptions.swift
+++ b/Notice/Subscriptions.swift
@@ -1,29 +1,27 @@
 protocol SubscriptionsType {
-    typealias ValueType
+    typealias EventType: Event
 
-    var subscriptions: Set<Subscription<ValueType>> { get set }
+    var subscriptions: Set<Subscription<EventType>> { get set }
 
-    mutating func add(subscription: Subscription<ValueType>)
-    mutating func remove(subscription: Subscription<ValueType>)
-    func send(value: ValueType)
+    mutating func add(subscription: Subscription<EventType>)
+    mutating func remove(subscription: Subscription<EventType>)
+    func send(value: EventType)
 }
 
 extension SubscriptionsType {
-    mutating func add(subscription: Subscription<ValueType>) {
+    mutating func add(subscription: Subscription<EventType>) {
         subscriptions.insert(subscription)
     }
 
-    mutating func remove(subscription: Subscription<ValueType>) {
+    mutating func remove(subscription: Subscription<EventType>) {
         subscriptions.remove(subscription)
     }
 }
 
-class Subscriptions<T>: SubscriptionsType {
-    typealias ValueType = T
+class Subscriptions<EventType: Event>: SubscriptionsType {
+    var subscriptions = Set<Subscription<EventType>>()
 
-    var subscriptions = Set<Subscription<ValueType>>()
-
-    func send(value: ValueType) {
-        subscriptions.forEach { $0.handler(value) }
+    func send(event: EventType) {
+        subscriptions.forEach { $0.handle(event) }
     }
 }


### PR DESCRIPTION
- Create an extendible `Event` protocol which can be used on a `Subscription` or `Subscriptions`
- Implement `NewEvent` and `NewOldEvent` types
- Make `Observable` have two different `subscribe(options:handler:)` functions for `NewEvent` and `NewOldEvent`
