### PR TITLE
Migrating to Swift 2.3

### DIFF
--- a/Notice.xcodeproj/project.pbxproj
+++ b/Notice.xcodeproj/project.pbxproj
@@ -154,9 +154,11 @@
 				TargetAttributes = {
 					26BD50FE1CA331BC009408FE = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 					396F33611BB3461F00792AB5 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -232,6 +234,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.markadams.NoticeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -243,6 +246,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.markadams.NoticeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -351,6 +355,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -369,6 +374,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.markadams.Notice;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
No change really needed here, but here is the recompiled framework using Swift 2.3.
[Notice.framework.zip](https://github.com/hyperspacemark/Notice/files/354953/Notice.framework.zip)
